### PR TITLE
Remove environment files from .dockerignore to allow inclusion of .en…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,10 +12,6 @@ out
 coverage
 .nyc_output
 
-# Environment files
-.env
-.env.*
-!.env.example
 
 # Version control
 .git


### PR DESCRIPTION
…v.example while excluding other .env files.